### PR TITLE
みずほ銀行で追加認証が毎回必要となる

### DIFF
--- a/server/mhbk.inc
+++ b/server/mhbk.inc
@@ -197,7 +197,7 @@ if(strpos($body, "合言葉確認２") !== false) {
 		if(isset($queries["chkConfItemChk"]) == true) {
 			if(ENV_BOOL_ADD_RISKBASE == true) {
 				// 次回ログイン時に合言葉を入力しない
-				$queries["chkConfItemChk"] = "chkConfItemChk=";
+				$queries["chkConfItemChk"] = "";
 			} else {
 				// 次回ログイン時に合言葉を入力する
 				$queries["chkConfItemChk"] = "chkConfItemChk=on";


### PR DESCRIPTION
通常の方法でみずほダイレクトにログインすると初回のみ追加認証が必要ですが、２回目以降は追加認証が不要です。
一方、ofxproxyを用いると毎回追加認証が必要となってしまいます。
解決は可能でしょうか？
