### PR TITLE
住信SBIネット銀行と連携していない場合でも現金残高を取得する

### DIFF
--- a/server/sbisec.inc
+++ b/server/sbisec.inc
@@ -176,6 +176,7 @@ if(strpos($body, "ログイン後の全てのサービスを停止") !== false) 
 				$marginbalance = parse_amount($v);
 				break;
 			case "現金残高等（合計）":
+			case "現金残高等":
 				// 現金残高等（合計）を取得する
 				$availcash = parse_amount($v);
 				break;


### PR DESCRIPTION
当方の口座は、住信SBIネット銀行と連携させていません。
その場合の口座サマリーは添付の画像のとおりです。
「現金残高等（合計）」ではなく、「現金残高等」であるため、AVAILCASHが取得できません。
本パッチは、「現金残高等」の場合であっても現金残高を取得するためのものです。
<img width="252" alt="screen shot 2015-11-22 at 10 01 44 pm" src="https://cloud.githubusercontent.com/assets/1708361/11323929/af356862-9164-11e5-8071-e7043466a4cc.png">
