### PR TITLE
住信SBIネット銀行と未連携の場合でも<MARGINBALANCE>を取得する

### DIFF
--- a/server/sbisec.inc
+++ b/server/sbisec.inc
@@ -176,9 +176,14 @@ if(strpos($body, "ログイン後の全てのサービスを停止") !== false) 
 				$marginbalance = parse_amount($v);
 				break;
 			case "現金残高等（合計）":
-			case "現金残高等":
 				// 現金残高等（合計）を取得する
 				$availcash = parse_amount($v);
+				break;
+			case "現金残高等":
+				// 現金残高等を取得する
+				// （住信SBIネット銀行と未連携の場合が該当）
+				$availcash = parse_amount($v);
+				$marginbalance = $availcash;
 				break;
 			default:
 				break;


### PR DESCRIPTION
#18 #19 でお伝えしたように、住信SBIネット銀行と連携していない場合、「SBI証券口座分」の列が存在しません。結果として、MARGINBALANCEが0となってしまいます。

本パッチにより、住信SBIネット銀行と未連携の場合でもMARGINBALANCEを取得できるようになります。
