### PR TITLE
ユーザが明細取得期間を指定できない

### DIFF
--- a/server/rakutensec.inc
+++ b/server/rakutensec.inc
@@ -9,6 +9,18 @@ Licensed under the GNU AGPLv3.
 $resp = array();
 $ofx = "";
 
+// DTSTARTとDTENDを設定する
+if (array_key_exists('DTSTART', $ofxforms)) {
+    $dtstart = $ofxforms['DTSTART'];
+} else {
+    $dtstart = ENV_STR_DATE_PASTDAY;
+}
+if (array_key_exists('DTEND', $ofxforms)) {
+    $dtend = $ofxforms['DTEND'];
+} else {
+    $dtend = ENV_STR_DATE_TODAY;
+}
+
 // 実行時間（タイムアウト）を再設定する
 @set_time_limit(ENV_NUM_TIMEOUT);
 
@@ -182,7 +194,7 @@ foreach ($rows as $row) {
     $cd["FITID"] = '000';
 
     // 入出力履歴をDOMに書き込む
-    if (strtotime(ENV_STR_DATE_PASTDAY) <= strtotime($row[0]) && strtotime($row[0]) <= strtotime(ENV_STR_DATE_TODAY)) {
+    if (strtotime($dtstart) <= strtotime($row[0]) && strtotime($row[0]) <= strtotime($dtend)) {
         $ofxdom->addTran($cd);
     } else {
         break;
@@ -190,7 +202,7 @@ foreach ($rows as $row) {
 }
 
 // DTSTARTとDTENDを設定する
-$ofxdom->setDateRange(ENV_STR_DATE_PASTDAY . ENV_STR_OFX_TZ, ENV_STR_DATE_TODAY . ENV_STR_OFX_TZ);
+$ofxdom->setDateRange($dtstart . ENV_STR_OFX_TZ, $dtend . ENV_STR_OFX_TZ);
 
 // 取引履歴（国内株式）のCSVを処理する
 $body_trade_jp = mb_convert_encoding($body_trade_jp, "UTF-8", "sjis-win");
@@ -222,7 +234,7 @@ foreach ($rows as $row) {
         $ct['UNITS'] *= -1;
     }
 
-    if (strtotime(ENV_STR_DATE_PASTDAY) <= strtotime($row[0]) && strtotime($row[0]) <= strtotime(ENV_STR_DATE_TODAY)) {
+    if (strtotime($dtstart) <= strtotime($row[0]) && strtotime($row[0]) <= strtotime($dtend)) {
         $ofxdom->addTrade($ct);
     }
 }
@@ -269,7 +281,7 @@ foreach ($rows as $row) {
             break;
     }
 
-    if (strtotime(ENV_STR_DATE_PASTDAY) <= strtotime($row[0]) && strtotime($row[0]) <= strtotime(ENV_STR_DATE_TODAY)) {
+    if (strtotime($dtstart) <= strtotime($row[0]) && strtotime($row[0]) <= strtotime($dtend)) {
         $ofxdom->addTrade($ct);
     }
 }


### PR DESCRIPTION
以前お話したことがありますが、現在、ユーザがDTSTARTとDTENDを指定できず、明細取得期間はプラグイン毎の実装に依存しています。
結果として、みずほ銀行であれば「前々月1日から本日までの明細」、三菱東京UFJ銀行であれば「前月1日から本日」と、バラバラです。
一方、OFXの仕様においては、クライアントがDTSTARTとDTENDを指定できるようになっています。

そこで提案なのですが、server.phpへのPOSTのクエリに、DTSTARTとDTENDを指定できるようにするのはいかがでしょうか？
あくまでserver.phpがDTSTARTとDTENDを受け入れるかどうかであり、index.phpでDTSTARTとDTENDを指定させるかは別です。すなわち、ブラウザでOFXProxyを利用しているユーザのUIは必ずしも変更の必要はないと思っています。

実装上は以下の２点がポイントになります（抜け漏れあればご指摘ください）。
１．server.phpでは、DTSTART <= DTENDを確認
２．各プラグインでは、何月の明細ページを取得するか判定し、得られた各明細をレスポンスに含めるか否か判定
２の実装が少し複雑で、クレジットカードの場合（請求月と使用した月が異なる）はより複雑になります。

すぐに答えを出す必要はないと思いますが、まずは議論を始めさせていただきたいです。
検討の結果、やはり実装が困難だ、となった時であっても、代案としてプラグイン間でバラバラとなっている明細取得期間を統一することもありかなと思っています。最悪、銀行、証券、というカテゴリ毎の統一でもよいです。

長文になりましたが、ご検討のほどよろしくお願いいたします。
