### PR TITLE
#27「SBI証券の分配金再投資の明細が正しくない」への対応

### DIFF
--- a/server.inc
+++ b/server.inc
@@ -216,20 +216,26 @@ class ofxDOM {
 
 	// 取引履歴を書き込む
 	public function addTrade($ct) {
-		$array = array('UNITS', 'UNITPRICE', 'COMMISSION', 'TAXES', 'FEES', 'TOTAL', 'SUBACCTSEC');
 		if ($ct['BUYTYPE'] == ENV_STR_OFX_REINVEST) {
-			array_push($array, 'INCOMETYPE');
+			$array = array('INCOMETYPE', 'TOTAL', 'SUBACCTSEC', 'UNITS', 'UNITPRICE');
 			$parent = $this->tranlist->addChild('REINVEST');
-		} else if ($ct['BUYTYPE'] == ENV_STR_OFX_BUY) {
-			array_push($array, 'SUBACCTFUND');
-			$tran = $this->tranlist->addChild($ct['BUYTYPE'] . $ct['CATEGORY']);
-			$parent = $tran->addChild('INV' . $ct['BUYTYPE']);
-			$tran->addChild('BUYTYPE', $ct['BUYTYPE']);
 		} else {
-			array_push($array, 'SUBACCTFUND');
+			$array = array('UNITS', 'UNITPRICE');
+			switch($ct['CATEGORY']) {
+			case ENV_STR_OFX_STOCK:
+				array_push($array, 'TAXES', 'FEES');
+				break;
+			case ENV_STR_OFX_FUND:
+				array_push($array, 'COMMISSION', 'TAXES');
+				break;
+			case ENV_STR_OFX_CASH:
+			default:
+				break;
+			}
+			array_push($array, 'TOTAL', 'SUBACCTSEC', 'SUBACCTFUND');
 			$tran = $this->tranlist->addChild($ct['BUYTYPE'] . $ct['CATEGORY']);
 			$parent = $tran->addChild('INV' . $ct['BUYTYPE']);
-			$tran->addChild('SELLTYPE', $ct['BUYTYPE']);
+			$tran->addChild($ct["BUYTYPE"] . 'TYPE', $ct['BUYTYPE']);
 		}
 		$invtran = $parent->addChild('INVTRAN');
 		$invtran->addChild('FITID', $ct['FITID']);

--- a/server/sbisec.inc
+++ b/server/sbisec.inc
@@ -699,6 +699,9 @@ if(strpos($body, "ログイン後の全てのサービスを停止") !== false) 
 			$ct["SUBACCTSEC"] = ENV_STR_OFX_CASH;
 			$ct["SUBACCTFUND"] = ENV_STR_OFX_CASH;
 			$ct["BUYTYPE"] = $ct_buytype;
+			if ($ct["BUYTYPE"] == ENV_STR_OFX_REINVEST) {
+				$ct["INCOMETYPE"] = ENV_STR_OFX_TRNTYPE_DIV;
+			}
 			array_push($cts, $ct);
 			
 			$ct_date = $ct_dttrade;


### PR DESCRIPTION
当方の環境では、SBI証券の分配金再投資の明細が存在せず、検証ができません。
代わりと言ってはなんですが、楽天証券のOFX（分配金再投資の明細を含む）に対し、OFXAnalyzerがエラーを吐かないことを確認しています。

$ct['BUYTYPE']や$ct['CATEGORY']による分岐ロジックについては、下記を参考にしました。
https://github.com/outerguy/ofxproxy/blob/5916f4a00d473d2673ca823614f3312f3a62cb2e/server/sbisec.inc#L725-L769
