### PR TITLE
特殊文字に関するPHPのバグを回避

### DIFF
--- a/server.inc
+++ b/server.inc
@@ -208,10 +208,15 @@ class ofxDOM {
 			$parent = $this->tranlist;
 			$stmttrn = $parent->addChild('STMTTRN');
 		}
-		$array = array('TRNTYPE', 'DTPOSTED', 'TRNAMT', 'FITID', 'NAME', 'MEMO');
+		$array = array('TRNTYPE', 'DTPOSTED', 'TRNAMT', 'FITID');
 		foreach($array as $key) {
 			$stmttrn->addChild($key, $cd[$key]);
 		}
+		// 特殊文字に関するPHPのバグ（https://bugs.php.net/bug.php?id=39521）を回避
+		$stmttrn->addChild('NAME');
+		$stmttrn->NAME = $cd['NAME'];
+		$stmttrn->addChild('MEMO');
+		$stmttrn->MEMO = $cd['MEMO'];
 	}
 
 	// 取引履歴を書き込む


### PR DESCRIPTION
&amp;がNAMEやMEMOに含まれている場合に、当該NAMEやMEMOが空欄になってしまうバグを修正しました。
バグ自体は既知でhttps://bugs.php.net/bug.php?id=39521で報告されています。
回避方法はhttp://php.net/manual/ja/simplexmlelement.addchild.phpを参考にしました。
