### PR TITLE
ワンタイムパスワード入力画面の検知失敗を修正

### DIFF
--- a/server/btmu.inc
+++ b/server/btmu.inc
@@ -81,7 +81,7 @@ if($sid == 0) {
 	}
 }
 
-if(strpos($body, "普段と異なる環境からのアクセス") !== false) {
+if(strpos($body, "ワンタイムパスワード") !== false) {
 	// ワンタイムパスワードを入力する
 	$divs = parse_tag($body, "div");
 	$c = parse_tag_search($divs, "class", "serviceContents");


### PR DESCRIPTION
三菱東京UFJ銀行のワンタイムパスワード入力画面には、現在「普段と異なる環境からのアクセス」の文字列は含まれないようです。
