### PR TITLE
２頁目以降の明細を取得できないバグを修正

### DIFF
--- a/server/mufgcard.inc
+++ b/server/mufgcard.inc
@@ -201,6 +201,20 @@ if(strpos($body, "現在サービス停止中") !== false || strpos($body, "シ�
             $cookie = mufgcard_updatecookie($head, $cookie);
             list($head, $body) = mufgcard_http11($method, $uris["scheme"], $uris["host"], $uris["path"], $uris["query"], $cookie);
             array_push($bodies, $body);
+            while(preg_match("/.*next\.html.*/", $body)) {
+                $forms = parse_tag($body, "form");
+                $c = parse_tag_search($forms, "action", "/inet/dy/meisaisyokai/next.html#meisai");
+                $inputs = parse_tag($forms[$c]["innerHTML"], "input");
+                $queries = array();
+                foreach($inputs as $input) if($input["name"] != "") $queries[$input["name"]] = urlencode($input["name"]) . "=" . urlencode($input["value"]);
+
+                $method = $forms[$c]["method"];
+                $uris = parse_uri($forms[$c]["action"], $uris);
+                $query = implode("&", $queries);
+                $cookie = mufgcard_updatecookie($head, $cookie);
+                list($head, $body) = mufgcard_http11($method, $uris["scheme"], $uris["host"], $uris["path"], $query, $cookie);
+                array_push($bodies, $body);
+            }
         }
     }
     


### PR DESCRIPTION
タイトル通りのバグを修正しました。

ところで、ボタンを押して画面遷移をする、という機能がserver.incにあると便利だと思いました。
もちろんその際に、hiddenなinputなども考慮するとよいです。
例えば、pythonの[mechanize](http://wwwsearch.sourceforge.net/mechanize/#examples)のような下記の挙動になるとよいと思いますが、いかがでしょうか。
`br.select_form(name="order")`
`response2 = br.submit()`
